### PR TITLE
增加在action中导出markdown的功能

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: boolean
         default: false
+      export_md:
+        description: "Export as Markdown attachment (uncheck to send as HTML email)"
+        required: false
+        type: boolean
+        default: false
       sub_ids:
         description: "Optional comma-separated lecture sub_ids to filter (default: all summarized lectures)"
         required: false
@@ -86,10 +91,15 @@ jobs:
           RECEIVER_EMAIL: ${{ secrets.RECEIVER_EMAIL }}
           EXPORT_COURSE_ID: ${{ inputs.course_id }}
           EXPORT_SUB_IDS: ${{ inputs.sub_ids }}
+          EXPORT_MD: ${{ inputs.export_md }}
         run: |
           PDF_FLAG=""
+          MD_FLAG=""
           if [ "${{ inputs.export_pdf }}" = "true" ]; then
             PDF_FLAG="--pdf"
+          fi
+          if [ "${{ inputs.export_md }}" = "true" ]; then
+            MD_FLAG="--md"
           fi
           if [ -n "$EXPORT_SUB_IDS" ]; then
             python scripts/export_course.py --course-id "$EXPORT_COURSE_ID" --sub-ids "$EXPORT_SUB_IDS" $PDF_FLAG

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -7,16 +7,14 @@ on:
         description: "Course ID(s) to export, comma-separated (e.g. 30004 or 30004,30005)"
         required: true
         type: string
-      export_pdf:
-        description: "Export as PDF attachment (uncheck to send as HTML email)"
-        required: false
-        type: boolean
-        default: false
-      export_md:
-        description: "Export as Markdown attachment (uncheck to send as HTML email)"
-        required: false
-        type: boolean
-        default: false
+      export_type:
+        description: "Choose export type,if use HTML email,there will be no attachment, just the email body."
+        type: choice
+        options:
+          - HTML
+          - PDF
+          - Markdown
+        default: 'HTML'
       sub_ids:
         description: "Optional comma-separated lecture sub_ids to filter (default: all summarized lectures)"
         required: false
@@ -93,16 +91,19 @@ jobs:
           EXPORT_SUB_IDS: ${{ inputs.sub_ids }}
           EXPORT_MD: ${{ inputs.export_md }}
         run: |
-          PDF_FLAG=""
-          MD_FLAG=""
-          if [ "${{ inputs.export_pdf }}" = "true" ]; then
-            PDF_FLAG="--pdf"
-          fi
-          if [ "${{ inputs.export_md }}" = "true" ]; then
-            MD_FLAG="--md"
-          fi
+          case "${{ inputs.export_type }}" in
+            "HTML")
+              EXPORT_FLAG=""
+              ;;
+            "PDF")
+              EXPORT_FLAG="--pdf"
+              ;;
+            "Markdown")
+              EXPORT_FLAG="--md"
+              ;;
+          esac
           if [ -n "$EXPORT_SUB_IDS" ]; then
-            python scripts/export_course.py --course-id "$EXPORT_COURSE_ID" --sub-ids "$EXPORT_SUB_IDS" $PDF_FLAG $MD_FLAG
+            python scripts/export_course.py --course-id "$EXPORT_COURSE_ID" --sub-ids "$EXPORT_SUB_IDS" $EXPORT_FLAG
           else
-            python scripts/export_course.py --course-id "$EXPORT_COURSE_ID" $PDF_FLAG $MD_FLAG
+            python scripts/export_course.py --course-id "$EXPORT_COURSE_ID" $EXPORT_FLAG
           fi

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -102,7 +102,7 @@ jobs:
             MD_FLAG="--md"
           fi
           if [ -n "$EXPORT_SUB_IDS" ]; then
-            python scripts/export_course.py --course-id "$EXPORT_COURSE_ID" --sub-ids "$EXPORT_SUB_IDS" $PDF_FLAG
+            python scripts/export_course.py --course-id "$EXPORT_COURSE_ID" --sub-ids "$EXPORT_SUB_IDS" $PDF_FLAG $MD_FLAG
           else
-            python scripts/export_course.py --course-id "$EXPORT_COURSE_ID" $PDF_FLAG
+            python scripts/export_course.py --course-id "$EXPORT_COURSE_ID" $PDF_FLAG $MD_FLAG
           fi

--- a/scripts/export_course.py
+++ b/scripts/export_course.py
@@ -158,6 +158,26 @@ def _send_pdf_email(subject: str,
     with _smtp_connect() as server:
         server.sendmail(config.SMTP_EMAIL, config.RECEIVER_EMAIL, msg.as_string())
 
+def _send_md_email(subject: str, md_content: list[tuple[bytes, str]]) -> None:
+    """Send an email with Markdown content.
+
+    Args:
+        md_content: List of ``(md_bytes, filename)`` tuples.
+    """
+    msg = MIMEMultipart()
+    msg["Subject"] = subject
+    msg["From"] = formataddr(("iCourse Subscriber", config.SMTP_EMAIL))
+    msg["To"] = config.RECEIVER_EMAIL
+
+    for md_bytes, filename in md_content:
+        part = MIMEBase("text", "markdown", name=filename)
+        part.set_payload(md_bytes)
+        encoders.encode_base64(part)
+        part.add_header("Content-Disposition", "attachment", filename=filename)
+        msg.attach(part)
+
+    with _smtp_connect() as server:
+        server.sendmail(config.SMTP_EMAIL, config.RECEIVER_EMAIL, msg.as_string())
 
 def _safe_filename(title: str) -> str:
     """Sanitise a course title for use as a filename."""
@@ -225,6 +245,11 @@ def main():
         help="Export as PDF attachment instead of inline HTML email",
     )
     parser.add_argument(
+        "--md",
+        action="store_true",
+        help="Export as Markdown attachment instead of HTML email (experimental)",
+    )
+    parser.add_argument(
         "--db", default="data/icourse.db",
         help="Database path (default: data/icourse.db)",
     )
@@ -283,6 +308,33 @@ def main():
         total_bytes = sum(len(b) for b, _ in attachments)
         print(f"Sending email with {len(attachments)} PDF(s) ({total_bytes} bytes)...")
         _send_pdf_email(subject, attachments)
+        print(f"[OK] Sent: {subject}")
+
+    elif args.md:
+        # Markdown mode: one MD file per course, all files in one email
+        attachments: list[tuple[bytes, str]] = []
+        titles: list[str] = []
+        for cid in course_ids:
+            result = _query_course(db, cid, sub_ids=sub_ids)
+            if result is None:
+                continue
+            course_title, teacher, lectures = result
+            titles.append(course_title)
+
+            markdown:str = _build_plain(course_title, teacher, lectures, pdf=True)
+            markdown_bytes = markdown.encode("utf-8")
+            filename = f"{_safe_filename(course_title)}_summaries.md"
+            attachments.append((markdown_bytes, filename))
+            print(f"  Markdown ready ({len(markdown_bytes)} bytes): {filename}")
+
+        if not attachments:
+            print("No courses with summaries found – nothing to send.")
+            sys.exit(0)
+
+        subject = "[iCourse 课程摘要导出] " + ", ".join(titles)
+        total_bytes = sum(len(b) for b, _ in attachments)
+        print(f"Sending email with {len(attachments)} MD(s) ({total_bytes} bytes)...")
+        _send_md_email(subject, attachments)
         print(f"[OK] Sent: {subject}")
 
     else:

--- a/scripts/export_course.py
+++ b/scripts/export_course.py
@@ -95,7 +95,7 @@ def _build_plain(course_title: str, teacher: str, lectures: list[dict]) -> str:
         # parts.append(f"\n{'─' * 40}")
         parts.append(f"## {lec['sub_title']} ({lec['date']})")
         # parts.append("─" * 40)
-        # parts.append(lec["summary"])
+        parts.append(lec["summary"])
     return "\n".join(parts)
 
 

--- a/scripts/export_course.py
+++ b/scripts/export_course.py
@@ -321,7 +321,7 @@ def main():
             course_title, teacher, lectures = result
             titles.append(course_title)
 
-            markdown:str = _build_plain(course_title, teacher, lectures, pdf=True)
+            markdown:str = _build_plain(course_title, teacher, lectures)
             markdown_bytes = markdown.encode("utf-8")
             filename = f"{_safe_filename(course_title)}_summaries.md"
             attachments.append((markdown_bytes, filename))

--- a/scripts/export_course.py
+++ b/scripts/export_course.py
@@ -87,15 +87,15 @@ def _build_html(course_title: str, teacher: str, lectures: list[dict],
 def _build_plain(course_title: str, teacher: str, lectures: list[dict]) -> str:
     """Build a plain-text version of the summaries."""
     parts = [
-        f"课程：{course_title}",
+        f"# 课程：{course_title}",
         f"任课教师：{teacher}",
-        "=" * 40,
+        # "=" * 40,
     ]
     for lec in lectures:
-        parts.append(f"\n{'─' * 40}")
-        parts.append(f"{lec['sub_title']} ({lec['date']})")
-        parts.append("─" * 40)
-        parts.append(lec["summary"])
+        # parts.append(f"\n{'─' * 40}")
+        parts.append(f"## {lec['sub_title']} ({lec['date']})")
+        # parts.append("─" * 40)
+        # parts.append(lec["summary"])
     return "\n".join(parts)
 
 


### PR DESCRIPTION
在export_course.py中增加了发送markdown的选项，在action中把导出格式选项从checkbox换成了choice

代码变更：
[export.yml](https://github.com/LeafCreeper/Fudan_iCourse_Subscriber/compare/main...ABiscuitttt:Fudan_iCourse_Subscriber:export_md?expand=1#diff-abd067ac9ffcb98dd6b5da7a1bff2138d3a3a9ced0ba8f74886fbbe3d7686540)
这里变更比较简单，主要是换成choice类型，改了一下传参
  
[export_course.py](https://github.com/LeafCreeper/Fudan_iCourse_Subscriber/compare/main...ABiscuitttt:Fudan_iCourse_Subscriber:export_md?expand=1#diff-cf3c76dc1a825fc2be45eaba119f13430106d449567f735b68c7085190c54fc8)
仿照send pdf email新增了一个发送md的函数，
在if pdf ，else html中间加了elif md

把build plain里面对标题的格式化改成了markdown标题