### PR TITLE
ci: cache pip across export/reset_data/reshard workflows

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -37,8 +37,16 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Cache Python packages
+        id: cache-pip
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.pythonLocation }}/lib/python*/site-packages
+          key: pip-${{ hashFiles('requirements.txt') }}
+
       - name: Install Python dependencies
-        run: pip install markdown pillow requests pygments
+        if: steps.cache-pip.outputs.cache-hit != 'true'
+        run: pip install -r requirements.txt
 
       - name: Install PDF dependencies
         if: inputs.export_pdf == true

--- a/.github/workflows/reset_data.yml
+++ b/.github/workflows/reset_data.yml
@@ -39,6 +39,17 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Cache Python packages
+        id: cache-pip
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.pythonLocation }}/lib/python*/site-packages
+          key: pip-${{ hashFiles('requirements.txt') }}
+
+      - name: Install Python dependencies
+        if: steps.cache-pip.outputs.cache-hit != 'true'
+        run: pip install -r requirements.txt
+
       - name: Fetch database from data branch
         run: |
           mkdir -p data

--- a/.github/workflows/reshard.yml
+++ b/.github/workflows/reshard.yml
@@ -18,7 +18,15 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Cache Python packages
+        id: cache-pip
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.pythonLocation }}/lib/python*/site-packages
+          key: pip-${{ hashFiles('requirements.txt') }}
+
       - name: Install Python dependencies
+        if: steps.cache-pip.outputs.cache-hit != 'true'
         run: pip install -r requirements.txt
 
       - name: Fetch encrypted database from data branch


### PR DESCRIPTION
Architecture-independent CI improvement, safe to merge ahead of the frontend rework. Add a shared pip cache keyed on requirements.txt and install via `pip install -r requirements.txt`, reusing the same cache key/path as check.yml so the cache is shared across workflows. export previously hand-listed markdown/pillow/requests/pygments, all already in requirements.txt (weasyprint/pygments stay as a conditional PDF-only install).