### PR TITLE
feat: 支持自定义 OpenAI 兼容 provider

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,12 @@ on:
     # 设计这个奇怪的时间是为了避免整点时的github队列峰值，避免排队过久。
     - cron: "36 11 * * *"
   workflow_dispatch:
+    inputs:
+      resummarize_all:
+        description: "Re-summarize every existing lecture with the current LLM"
+        required: false
+        default: "false"
+        type: boolean
 
 permissions:
   contents: write
@@ -169,9 +175,17 @@ jobs:
           COURSE_IDS: ${{ secrets.COURSE_IDS }}
           CRAWL_TERM: ${{ secrets.CRAWL_TERM }}
           RESUMMARIZE_OLD: "1"
+          RESUMMARIZE_ALL: ${{ github.event_name == 'workflow_dispatch' && inputs.resummarize_all && '1' || '' }}
+          RUN_SOFT_TIMEOUT_MINUTES: "330"
+          CUSTOM_OPENAI_API_KEY: ${{ secrets.CUSTOM_OPENAI_API_KEY }}
+          CUSTOM_OPENAI_BASE_URL: ${{ secrets.CUSTOM_OPENAI_BASE_URL }}
+          CUSTOM_OPENAI_MODEL: ${{ secrets.CUSTOM_OPENAI_MODEL }}
           DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
+          DASHSCOPE_BASE_URL: ${{ secrets.DASHSCOPE_BASE_URL }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          DEEPSEEK_BASE_URL: ${{ secrets.DEEPSEEK_BASE_URL }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GEMINI_BASE_URL: ${{ secrets.GEMINI_BASE_URL }}
           SMTP_EMAIL: ${{ secrets.SMTP_EMAIL }}
           SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
           RECEIVER_EMAIL: ${{ secrets.RECEIVER_EMAIL }}

--- a/.github/workflows/single_run.yml
+++ b/.github/workflows/single_run.yml
@@ -7,6 +7,11 @@ on:
         description: "Comma-separated course IDs to process (e.g. 30004,30005)"
         required: true
         type: string
+      resummarize_all:
+        description: "Re-summarize every existing lecture in these courses"
+        required: false
+        default: "false"
+        type: boolean
 
 permissions:
   contents: write
@@ -157,8 +162,18 @@ jobs:
           StuId: ${{ secrets.STUID }}
           UISPsw: ${{ secrets.UISPSW }}
           COURSE_IDS: ${{ inputs.course_ids }}
+          RESUMMARIZE_OLD: ${{ inputs.resummarize_all && '1' || '' }}
+          RESUMMARIZE_ALL: ${{ inputs.resummarize_all && '1' || '' }}
+          RUN_SOFT_TIMEOUT_MINUTES: "330"
+          CUSTOM_OPENAI_API_KEY: ${{ secrets.CUSTOM_OPENAI_API_KEY }}
+          CUSTOM_OPENAI_BASE_URL: ${{ secrets.CUSTOM_OPENAI_BASE_URL }}
+          CUSTOM_OPENAI_MODEL: ${{ secrets.CUSTOM_OPENAI_MODEL }}
           DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
+          DASHSCOPE_BASE_URL: ${{ secrets.DASHSCOPE_BASE_URL }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          DEEPSEEK_BASE_URL: ${{ secrets.DEEPSEEK_BASE_URL }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GEMINI_BASE_URL: ${{ secrets.GEMINI_BASE_URL }}
           SMTP_EMAIL: ${{ secrets.SMTP_EMAIL }}
           SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
           RECEIVER_EMAIL: ${{ secrets.RECEIVER_EMAIL }}

--- a/README.md
+++ b/README.md
@@ -37,13 +37,16 @@
 | `UISPSW` | ✅ | UIS 统一身份认证密码 | `your_password` |
 | `COURSE_IDS` | ✅ | 要监控的课程 ID，多个用英文逗号分隔 | `35472,30251` |
 | `DASHSCOPE_API_KEY` | ⬜ | ModelScope 平台 API Key | `ms-xxxxxxxx` |
+| `CUSTOM_OPENAI_API_KEY` | ⬜ | 自定义 OpenAI 兼容 API Key | `sk-xxxxxxxx` |
+| `CUSTOM_OPENAI_BASE_URL` | ⬜ | 自定义 OpenAI 兼容 API Base URL | `https://example.com/v1` |
+| `CUSTOM_OPENAI_MODEL` | ⬜ | 自定义 OpenAI 兼容模型名 | `gpt-5.5` |
 | `DEEPSEEK_API_KEY` | ⬜ | DeepSeek API Key（推荐） | `sk-xxxxxxxx` |
 | `GEMINI_API_KEY` | ⬜ | Gemini API Key | `AIza...` |
 | `SMTP_EMAIL` | ✅ | 用于发送邮件的 QQ 邮箱 | `123456@qq.com` |
 | `SMTP_PASSWORD` | ✅ | QQ 邮箱 SMTP **授权码**（不是登录密码） | `abcdefghijklmnop` |
 | `RECEIVER_EMAIL` | ✅ | 接收摘要邮件的邮箱 | `you@m.fudan.edu.com` |
 
-> 至少配置一个 LLM API Key（DASHSCOPE、DEEPSEEK 或 GEMINI）。程序按配置顺序自动回退尝试。如果需要选择其他的LLM供应商，可以在`src\runtime\config.py`路径下自定义供应商。
+> 至少配置一个 LLM API Key（CUSTOM_OPENAI、DASHSCOPE、DEEPSEEK 或 GEMINI）。程序按配置顺序自动回退尝试。如果需要选择其他的LLM供应商，可以在`src\runtime\config.py`路径下自定义供应商。
 
 ### 第 3 步：获取课程 ID
 
@@ -60,8 +63,11 @@
 | 服务商 | 获取方式 | 免费额度 |
 |---|---|---|
 | **ModelScope**（`DASHSCOPE_API_KEY`） | [API 密钥管理](https://modelscope.cn/my/myaccesstoken) | 每天 2000 次免费调用，推荐 |
+| **自定义 OpenAI 兼容 API**（`CUSTOM_OPENAI_*`） | 由 API 服务商提供 | 适合带专用 `base_url` 的 GPT/兼容模型 |
 | **DeepSeek**（`DEEPSEEK_API_KEY`） | [DeepSeek Platform](https://platform.deepseek.com/) | 注册赠额度 |
 | **Gemini**（`GEMINI_API_KEY`） | [Google AI Studio](https://aistudio.google.com/) | flash模型每日免费额度 |
+
+如果想把已有摘要全部用当前配置的模型重新生成，进入 Actions → **Single Run** 或 **iCourse Check** 手动运行，把 `resummarize_all` 设为 `true`。定时任务不会自动全量重跑，避免消耗过多 API 额度。
 
 ### 第 5 步：获取 QQ 邮箱 SMTP 授权码
 

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ Anything more interesting belongs in one of ``src/*`` modules.
 import datetime
 import time
 import traceback
+from typing import Callable
 
 from src.runtime import config
 from src.data.database import Database
@@ -140,7 +141,8 @@ def _drive_lectures(client: ICourseClient, db: Database,
                     scheduler: Scheduler, transcriber: Transcriber,
                     summarizer: Summarizer, reporter: Reporter,
                     all_lectures: list[tuple[str, str, dict]],
-                    email_items: list) -> None:
+                    email_items: list,
+                    should_stop: Callable[[], bool] | None = None) -> None:
     """Phase 2: run each lecture through LectureRunner.
 
     Pre-schedules the first lecture's prefetch (audio + images) before
@@ -158,6 +160,13 @@ def _drive_lectures(client: ICourseClient, db: Database,
     )
 
     for i, (course_id, course_title, lecture) in enumerate(all_lectures):
+        if should_stop and should_stop():
+            reporter.info(
+                "[Runtime] Soft time limit reached; stopping before the "
+                "next lecture so progress can be saved."
+            )
+            return
+
         sub_id = str(lecture["sub_id"])
         next_info: tuple[str, str] | None = None
         if i + 1 < len(all_lectures):
@@ -271,6 +280,14 @@ def run():
     """Single execution of the full pipeline."""
     reporter = Reporter()
     reporter.run_header()
+    run_started_at = time.time()
+
+    def should_stop_for_time() -> bool:
+        if config.RUN_SOFT_TIMEOUT_MINUTES <= 0:
+            return False
+        return (time.time() - run_started_at) >= (
+            config.RUN_SOFT_TIMEOUT_MINUTES * 60
+        )
 
     if not config.COURSE_IDS and not config.CRAWL_TERM:
         reporter.info(
@@ -311,14 +328,18 @@ def run():
         all_lectures = _enumerate_lectures(client, db, reporter)
         _drive_lectures(
             client, db, scheduler, transcriber, summarizer, reporter,
-            all_lectures, email_items,
+            all_lectures, email_items, should_stop=should_stop_for_time,
         )
 
         # Resummarize old (pre-v2) lectures, scoped to the courses we're
         # actively monitoring this run.  Opt-in via RESUMMARIZE_OLD=1
         # because re-OCR + re-LLM on every stale lecture turns a 5-min
         # nightly run into a 2-hour one; flip on for one-shot manual runs.
-        if config.RESUMMARIZE_OLD_ENABLED:
+        if config.RESUMMARIZE_OLD_ENABLED and should_stop_for_time():
+            reporter.info(
+                "\n[Resummarize] Skipping — soft time limit reached."
+            )
+        elif config.RESUMMARIZE_OLD_ENABLED:
             try:
                 _check_session(client)
                 ppt_pipeline = PPTPipeline(db, scheduler, reporter)
@@ -326,6 +347,8 @@ def run():
                     client, db, summarizer, ppt_pipeline, reporter,
                     email_items, config.COURSE_IDS,
                     check_session_fn=_check_session,
+                    should_stop=should_stop_for_time,
+                    force_all=config.RESUMMARIZE_ALL_ENABLED,
                 )
             except Exception:
                 reporter.info("[Resummarize] phase errored:")

--- a/scripts/resummarize_parallel.py
+++ b/scripts/resummarize_parallel.py
@@ -23,6 +23,7 @@ Usage:
     python scripts/resummarize_parallel.py                      # all
     python scripts/resummarize_parallel.py --limit 100          # first 100
     python scripts/resummarize_parallel.py --llm-workers 8      # more LLM concurrency
+    python scripts/resummarize_parallel.py --all                # force every summary
 """
 
 from __future__ import annotations
@@ -146,6 +147,11 @@ def main():
     parser.add_argument("--llm-workers", type=int, default=LLM_WORKERS)
     parser.add_argument("--limit", type=int, default=0)
     parser.add_argument("--course-ids", type=str, default="")
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="force every existing summary through the current LLM providers",
+    )
     args = parser.parse_args()
 
     global llm_queue
@@ -165,8 +171,14 @@ def main():
     # ── Phase 1: Catalog — scan targets + register PPT pages ─────────────
     if args.course_ids:
         cids = [c.strip() for c in args.course_ids.split(",") if c.strip()]
-        targets = db.get_lectures_to_resummarize_for_courses(cids)
+        targets = db.get_lectures_to_resummarize_for_courses(
+            cids, force_all=args.all,
+        )
     else:
+        if args.all:
+            print("--all requires --course-ids to keep the rewrite scoped.")
+            scheduler.shutdown()
+            return
         targets = db.get_lectures_to_resummarize()
     if not targets:
         print("No lectures need resummarize.")

--- a/src/ai/summarizer.py
+++ b/src/ai/summarizer.py
@@ -1,4 +1,4 @@
-"""LLM-based course lecture summarization via ModelScope API."""
+"""LLM-based course lecture summarization via OpenAI-compatible APIs."""
 
 import time
 

--- a/src/data/database.py
+++ b/src/data/database.py
@@ -421,11 +421,12 @@ class Database:
         return [dict(row) for row in rows]
 
     def get_lectures_to_resummarize_for_courses(
-        self, course_ids: list[str],
+        self, course_ids: list[str], force_all: bool = False,
     ) -> list[dict]:
         """Return lectures that need a re-OCR + re-summarize pass.
 
-        Two cases qualify (OR-ed together), both scoped to ``course_ids``:
+        In normal mode, two cases qualify (OR-ed together), both scoped to
+        ``course_ids``:
 
           v0 — old summary written before the PPT-aware prompt existed
                (``summary_format_version = 0``).  These never had PPT in
@@ -438,16 +439,18 @@ class Database:
         Once a lecture has *any* ppt_pages row (even one stamped ``failed``
         or ``invalid``), it is no longer eligible — we don't keep retrying
         a genuinely PPT-less lecture every run.
+
+        When ``force_all`` is true, every lecture with an existing summary in
+        the target courses qualifies.  This is intended for one-shot model
+        migration runs, such as redoing ModelScope summaries with a stronger
+        OpenAI-compatible endpoint.
         """
         if not course_ids:
             return []
         placeholders = ",".join("?" * len(course_ids))
-        rows = self.conn.execute(
-            f"""SELECT l.*, c.title AS course_title, c.teacher
-               FROM lectures l
-               JOIN courses c ON l.course_id = c.course_id
-               WHERE l.summary IS NOT NULL
-                 AND l.course_id IN ({placeholders})
+        extra_predicate = ""
+        if not force_all:
+            extra_predicate = """
                  AND (
                    COALESCE(l.summary_format_version, 0) = 0
                    OR (
@@ -457,7 +460,14 @@ class Database:
                        WHERE p.sub_id = l.sub_id
                      )
                    )
-                 )""",
+                 )"""
+        rows = self.conn.execute(
+            f"""SELECT l.*, c.title AS course_title, c.teacher
+               FROM lectures l
+               JOIN courses c ON l.course_id = c.course_id
+               WHERE l.summary IS NOT NULL
+                 AND l.course_id IN ({placeholders})
+                 {extra_predicate}""",
             list(course_ids),
         ).fetchall()
         return [dict(row) for row in rows]

--- a/src/pipeline/lecture_runner.py
+++ b/src/pipeline/lecture_runner.py
@@ -32,7 +32,8 @@ from __future__ import annotations
 
 import time
 import traceback
-from typing import TYPE_CHECKING, Optional
+from typing import Callable, Optional
+from typing import TYPE_CHECKING
 
 from src.ai import bucketer
 from src.pipeline.ppt_pipeline import PPTPipeline
@@ -281,7 +282,9 @@ def resummarize_old_lectures(client: "ICourseClient", db: "Database",
                              ppt_pipeline: PPTPipeline,
                              reporter: "Reporter",
                              email_items: list, course_ids: list[str],
-                             check_session_fn=None):
+                             check_session_fn=None,
+                             should_stop: Callable[[], bool] | None = None,
+                             force_all: bool = False):
     """Upgrade pre-v2 summaries to PPT-aware v2 format (flat-mode prompt).
 
     Old lectures kept their original transcript but never had PPT OCR.  We
@@ -291,15 +294,25 @@ def resummarize_old_lectures(client: "ICourseClient", db: "Database",
     suffix and a 更新 badge.
 
     Scoped to ``course_ids`` so we don't re-OCR courses the user isn't
-    monitoring this run.
+    monitoring this run.  ``force_all`` widens the target set to every
+    existing summary in those courses for one-shot model migration runs.
     """
-    targets = db.get_lectures_to_resummarize_for_courses(course_ids)
+    targets = db.get_lectures_to_resummarize_for_courses(
+        course_ids, force_all=force_all,
+    )
     if not targets:
         return
     reporter.resummarize_header(len(targets))
 
     seen_sub_ids = {item["sub_id"] for item in email_items}
     for idx, row in enumerate(targets, 1):
+        if should_stop and should_stop():
+            reporter.info(
+                "    [Resummarize] Soft time limit reached; stopping so "
+                "progress can be saved."
+            )
+            return
+
         sub_id = str(row["sub_id"])
         course_id = row["course_id"]
         sub_title = row.get("sub_title", sub_id)

--- a/src/runtime/config.py
+++ b/src/runtime/config.py
@@ -26,6 +26,15 @@ USER_AGENT = (
 # 现的那条；这避免 Summarizer 内部按 name 索引 client 字典时被后写覆盖。
 MODEL_PROVIDERS: list[dict] = [
     {
+        "name": "custom_openai",
+        "api_key_env": "CUSTOM_OPENAI_API_KEY",
+        "base_url_env": "CUSTOM_OPENAI_BASE_URL",
+        "default_base_url": "",
+        "models": [
+            (os.environ.get("CUSTOM_OPENAI_MODEL") or "gpt-5.5").strip()
+        ],
+    },
+    {
         "name": "modelscope",
         "api_key_env": "DASHSCOPE_API_KEY",
         "base_url_env": "DASHSCOPE_BASE_URL",
@@ -91,9 +100,12 @@ def resolve_model_providers() -> list[dict]:
         )
         if not base_url:
             continue
+        models = [m for m in p["models"] if m]
+        if not models:
+            continue
         if p["name"] in by_name:
             existing = by_name[p["name"]]
-            for m in p["models"]:
+            for m in models:
                 if m not in existing["models"]:
                     existing["models"].append(m)
             continue
@@ -101,7 +113,7 @@ def resolve_model_providers() -> list[dict]:
             "name": p["name"],
             "api_key": api_key,
             "base_url": base_url,
-            "models": list(p["models"]),
+            "models": models,
         }
         resolved.append(entry)
         by_name[p["name"]] = entry
@@ -166,11 +178,25 @@ VIDEO_DOWNLOAD_CONCURRENCY = int(
 
 # Resummarize phase opt-in.  Re-running OCR + LLM on every old lecture is
 # expensive (each lecture ~ a minute of LLM + 30 OCR calls); we don't want
-# every nightly run paying that cost.  Set RESUMMARIZE_OLD=1 to enable for
-# a one-shot manual workflow run.  Default off.
-RESUMMARIZE_OLD_ENABLED = os.environ.get("RESUMMARIZE_OLD", "").strip() in (
+# every nightly run paying that cost.  Set RESUMMARIZE_OLD=1 to upgrade only
+# stale/missing-PPT summaries, or RESUMMARIZE_ALL=1 to force every existing
+# summary through the current model provider stack.  Default off.
+RESUMMARIZE_ALL_ENABLED = os.environ.get("RESUMMARIZE_ALL", "").strip() in (
     "1", "true", "yes", "on",
 )
+RESUMMARIZE_OLD_ENABLED = os.environ.get("RESUMMARIZE_OLD", "").strip() in (
+    "1", "true", "yes", "on",
+) or RESUMMARIZE_ALL_ENABLED
+
+# GitHub-hosted runners have a 6-hour job ceiling.  When set, the main loop
+# stops taking new lecture/resummarize work after this many minutes so the
+# workflow still has time to upload the database and exit successfully.
+try:
+    RUN_SOFT_TIMEOUT_MINUTES = int(
+        os.environ.get("RUN_SOFT_TIMEOUT_MINUTES", "0") or "0"
+    )
+except ValueError:
+    RUN_SOFT_TIMEOUT_MINUTES = 0
 
 # 监控的课程 ID 列表
 COURSE_IDS = [


### PR DESCRIPTION
## 这个 PR 做了什么

在现有的 `MODEL_PROVIDERS` 列表式回退机制之上，新增一个 **`custom_openai`** provider，作为最高优先级条目，让用户可以接入任意 OpenAI 兼容接口（自定义 `base_url` + 模型名），而不局限于 ModelScope / DeepSeek / Gemini。

- **`src/runtime/config.py`**：在 `MODEL_PROVIDERS` 头部加入 `custom_openai`（读取 `CUSTOM_OPENAI_API_KEY` / `CUSTOM_OPENAI_BASE_URL` / `CUSTOM_OPENAI_MODEL`，默认模型 `gpt-5.5`）；`resolve_model_providers()` 增加“模型列表为空则跳过”的健壮性处理。
- **`.github/workflows/check.yml` / `single_run.yml`**：把 `CUSTOM_OPENAI_*` 及各 provider 的 `*_BASE_URL`、`DEEPSEEK_API_KEY` 注入运行环境。
- **`README.md`**：补充对应 Secret 说明。

按列表顺序自动回退的行为保持不变，只是多了一个可选的最高优先级 provider。

## 透明说明：本 PR 顺带还包含

`c9d974d` 这个提交除 provider 外，还捎带了两个相关改动。**如果你只想要 provider 部分，我可以拆分后重提：**

- **`resummarize_all` 手动开关**（`RESUMMARIZE_ALL_ENABLED`）：`workflow_dispatch` 时可强制用当前模型重跑全部已有摘要。
- **`RUN_SOFT_TIMEOUT_MINUTES` 软超时**：临近 GitHub Actions 6 小时上限时停止接新任务，保证有时间上传数据库再正常退出。

## 其他

- 基于现有 provider 基础设施，最小侵入。
- 本地 `py_compile` 通过。

方向 OK 的话，我可以按你的偏好拆成更小的 PR，或补文档/测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
