### PR TITLE
为邮件添加 Markdown 附件，保留原始 LaTeX 公式

### DIFF
--- a/src/api/emailer.py
+++ b/src/api/emailer.py
@@ -2,6 +2,7 @@ import re
 import smtplib
 import time
 import uuid
+from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import requests
 from io import BytesIO
@@ -406,6 +407,41 @@ class Emailer:
 
         if cid_images:
             print(f"[Emailer] Embedded {len(cid_images)} LaTeX images as CID")
+
+        # Build Markdown attachment with raw LaTeX formulas (no image rendering)
+        total_lectures = sum(len(lectures) for lectures in courses.values())
+        now = datetime.now()
+        md_sections = [
+            "---",
+            "title: iCourse 课程摘要",
+            f"generated: {now.isoformat()}",
+            f"courses: {len(courses)}",
+            f"lectures: {total_lectures}",
+            "---",
+            "",
+        ]
+        for course_title, lectures in courses.items():
+            md_sections.append(f"# {course_title}")
+            md_sections.append("")
+            for lec in lectures:
+                tag = " [更新]" if lec.get("is_update") else ""
+                lec_title = f"{lec['sub_title']} ({lec['date']})"
+                if tag:
+                    lec_title += tag
+                md_sections.append(f"## {lec_title}")
+                md_sections.append("")
+                md_sections.append(lec["summary"])
+                md_sections.append("")
+            md_sections.append("---")
+            md_sections.append("")
+
+        md_content = "\n".join(md_sections).strip() + "\n"
+        md_attachment = MIMEText(md_content, "markdown", "utf-8")
+        md_attachment.add_header(
+            "Content-Disposition", "attachment",
+            filename=f"fics-summaries-{now.strftime('%Y-%m-%d')}.md",
+        )
+        msg.attach(md_attachment)
 
         # Retry with exponential backoff
         for attempt in range(3):


### PR DESCRIPTION
## 概述

邮件正文中的数学公式通过 `latex.codecogs.com` 渲染为 PNG 图片后嵌入邮件.  
这在邮件客户端中展示效果良好，但图片形式的公式不利于后续 AI 工具处理.  
本 PR 在邮件中附加一个 `.md` 文件，其中公式以原始 LaTeX 源码形式保留，  
方便收件人将 Markdown 附件直接用于 AI 处理.

## 改动范围

仅修改 `src/api/emailer.py`，新增约 35 行代码.

## 设计决策

1. **附件内容范围**: 仅包含各讲座的摘要原文 (Markdown 格式)，不含邮件框架结构
2. **LaTeX 格式**: 保持 LLM 输出的原始 `$...$` (行内) / `$$...$$` (行间) 格式，不做转换
3. **附件命名**: `fics-summaries-YYYY-MM-DD.md` (按日期命名)
4. **MIME 类型**: `text/markdown`
5. **附件与正文关系**: 邮件正文保持现有图片公式不变，附件额外提供纯 LaTeX 版本，两者互不影响.
6. **展示方式**: `Content-Disposition: attachment`，收件人自行下载
7. **元数据**: 附件开头包含 YAML frontmatter (标题、生成时间、课程数、讲座数)
8. **多课程处理**: 一封邮件中的多个课程合并为一个 `.md` 文件，按 `# 课程标题` / `## 讲座标题` 分层组织

## 附件结构示例

```markdown
---
title: iCourse 课程摘要
generated: 2026-04-16T19:36:00.123456
courses: 2
lectures: 2
---

# 课程名 A

## 讲座标题 1 (2026-04-09)

### 课程内容小节
这里包含行内公式 $E=mc^2$ 和行间公式：

$$
\int_{-\infty}^{\infty} e^{-x^2}\,dx = \sqrt{\pi}
$$

## 讲座标题 2 (2026-04-16)

...

# 课程名 B

## 讲座标题 1 (2026-04-09)

...

## 讲座标题 2 (2026-04-16)

...
```

## 不涉及

- 不改动邮件正文的 HTML 渲染和用户体验
- 不改动 ASR / OCR / LLM 摘要流程
- 不改动前端代码
- 不影响数据库 Schema

## 测试建议

1. 在有 LaTeX 公式的课程上运行一次完整流水线
2. 检查邮件是否收到附件 `fics-summaries-YYYY-MM-DD.md`
3. 验证附件中的 `$...$` / `$$...$$` 公式可被 AI 工具正确解析

> **关于目标分支: ** 主仓库的 `dev` 分支已落后 `main` 超过 100 个 commit，因此本 PR 直接以 `main` 为目标.