### PR TITLE
fix: 每次运行发现新学期并按需抓取课程目录

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,6 @@ AudioDownloader.  This file does only orchestration:
 Anything more interesting belongs in one of ``src/*`` modules.
 """
 
-import datetime
 import time
 import traceback
 
@@ -229,11 +228,11 @@ def _send_email(emailer: Emailer | None, db: Database, reporter: Reporter,
 
 def _crawl_semester_catalog(client: ICourseClient, db: Database,
                             reporter: Reporter) -> None:
-    """Auto-discover every available semester and refresh ``all_courses``.
+    """Discover semesters on every run and fetch catalogs for new terms.
 
-    Walks every page of get-course-list for each discovered term and
-    replaces the term's catalog in one transaction.  No longer requires
-    the ``CRAWL_TERM`` secret — the API tells us what terms exist.
+    Compare API term names with the names stored in ``all_courses``.
+    Only terms with a successfully fetched catalog are considered known,
+    so empty or failed fetches are retried on the next run.
     """
     reporter.info("Discovering available semesters from API...")
     try:
@@ -250,7 +249,13 @@ def _crawl_semester_catalog(client: ICourseClient, db: Database,
     reporter.info(f"Found {len(terms)} semester(s): "
                   f"{', '.join(t['name'] for t in terms)}")
 
-    for term_info in terms:
+    known_terms = db.list_catalog_terms()
+    new_terms = [term for term in terms if term["name"] not in known_terms]
+    if not new_terms:
+        reporter.info("Skipping catalog crawl (no new semesters).")
+        return
+
+    for term_info in new_terms:
         code = term_info["code"]
         name = term_info["name"]
         expected = term_info["count"]
@@ -262,6 +267,12 @@ def _crawl_semester_catalog(client: ICourseClient, db: Database,
             if not rows:
                 reporter.info(f"  Term {name}: API returned 0 courses, skipping.")
                 continue
+            if len(rows) < expected:
+                reporter.info(
+                    f"  Term {name}: fetched {len(rows)} of {expected} courses, "
+                    "deferring catalog update until the next run."
+                )
+                continue
             # Pass the human-readable term name (not the API code) to the
             # DB so the frontend displays "2025-20262" instead of "25".
             deleted, upserted = db.upsert_all_courses_for_term(name, rows)
@@ -270,6 +281,7 @@ def _crawl_semester_catalog(client: ICourseClient, db: Database,
             )
         except Exception as e:
             reporter.crawl_courses_failed(name, e)
+            continue
         reporter.info(f"  ({code}) → {expected} API courses, "
                       f"{len(rows)} fetched")
 
@@ -302,14 +314,8 @@ def run():
     client = ICourseClient(vpn)
     email_items: list = []
 
-    # Refresh the semester catalog: run on the 9th and 25th of each month,
-    # or immediately if the database has no catalog data yet.
-    has_catalog = db.has_all_courses()
-    today = datetime.datetime.now().day
-    if not has_catalog or today in (9, 25):
-        _crawl_semester_catalog(client, db, reporter)
-    else:
-        reporter.info("Skipping catalog crawl (has data, not the 9th or 25th).")
+    # Discover new semesters every run; only fetch catalogs not yet stored.
+    _crawl_semester_catalog(client, db, reporter)
 
     if not config.COURSE_IDS:
         # Crawl-only mode: nothing to process, just persist + exit.

--- a/main.py
+++ b/main.py
@@ -302,14 +302,14 @@ def run():
     client = ICourseClient(vpn)
     email_items: list = []
 
-    # Refresh the semester catalog: run on the 5th and 25th of each month,
+    # Refresh the semester catalog: run on the 9th and 25th of each month,
     # or immediately if the database has no catalog data yet.
     has_catalog = db.has_all_courses()
     today = datetime.datetime.now().day
-    if not has_catalog or today in (5, 25):
+    if not has_catalog or today in (9, 25):
         _crawl_semester_catalog(client, db, reporter)
     else:
-        reporter.info("Skipping catalog crawl (has data, not the 5th or 25th).")
+        reporter.info("Skipping catalog crawl (has data, not the 9th or 25th).")
 
     if not config.COURSE_IDS:
         # Crawl-only mode: nothing to process, just persist + exit.

--- a/src/data/database.py
+++ b/src/data/database.py
@@ -164,7 +164,7 @@ class Database:
         """True if the catalog has any rows — cheap existence probe.
 
         Used by the nightly run to decide whether to skip the catalog
-        crawl on non-5th/25th days.  ``SELECT 1 ... LIMIT 1`` runs in
+        crawl on non-9th/25th days.  ``SELECT 1 ... LIMIT 1`` runs in
         microseconds even with 20k rows; the previous ``bool(list_all_courses())``
         materialised the whole catalog into Python just to call ``bool`` on it.
         """

--- a/src/data/database.py
+++ b/src/data/database.py
@@ -160,18 +160,13 @@ class Database:
                 ).fetchall()
         return [dict(r) for r in rows]
 
-    def has_all_courses(self) -> bool:
-        """True if the catalog has any rows — cheap existence probe.
-
-        Used by the nightly run to decide whether to skip the catalog
-        crawl on non-9th/25th days.  ``SELECT 1 ... LIMIT 1`` runs in
-        microseconds even with 20k rows; the previous ``bool(list_all_courses())``
-        materialised the whole catalog into Python just to call ``bool`` on it.
-        """
+    def list_catalog_terms(self) -> set[str]:
+        """Return stored semester names without loading the course catalog."""
         with self._lock:
-            return self.conn.execute(
-                "SELECT 1 FROM all_courses LIMIT 1"
-            ).fetchone() is not None
+            rows = self.conn.execute(
+                "SELECT DISTINCT term FROM all_courses"
+            ).fetchall()
+        return {row["term"] for row in rows}
 
     def insert_lecture(
         self, sub_id: str, course_id: str, sub_title: str, date: str

--- a/src/data/sharder.py
+++ b/src/data/sharder.py
@@ -308,7 +308,7 @@ def _build_meta_shard(source_db: str, output_path: str) -> None:
     """Build a tiny metadata-only shard containing ``all_courses`` and
     ``meta``.
 
-    ``all_courses`` changes infrequently (catalog refresh: 5th/25th of
+    ``all_courses`` changes infrequently (catalog refresh: 9th/25th of
     the month).  ``meta`` changes whenever PSA state or the persisted
     subscription set changes — both of which happen at most once per
     run.  Keeping this in a dedicated tiny shard lets the frontend's

--- a/src/data/sharder.py
+++ b/src/data/sharder.py
@@ -308,8 +308,8 @@ def _build_meta_shard(source_db: str, output_path: str) -> None:
     """Build a tiny metadata-only shard containing ``all_courses`` and
     ``meta``.
 
-    ``all_courses`` changes infrequently (catalog refresh: 9th/25th of
-    the month).  ``meta`` changes whenever PSA state or the persisted
+    ``all_courses`` changes when a new semester is discovered and its
+    catalog is fetched.  ``meta`` changes whenever PSA state or the persisted
     subscription set changes — both of which happen at most once per
     run.  Keeping this in a dedicated tiny shard lets the frontend's
     subscription editor know the catalog without decrypting any


### PR DESCRIPTION
当前课程目录仅在数据库为空或每月 5 日、25 日刷新，新学期在其他日期上线时无法及时发现。

每次运行都调用 `discover_terms()`，将接口返回的学期名称与数据库中已存的学期名称比较。只对尚未入库的学期遍历课程列表；没有新学期则跳过目录抓取。数据库为空时会抓取所有已发现学期，不再依赖固定日期。

通过 `SELECT DISTINCT term` 查询现有学期，避免加载完整课程目录。抓取异常、空结果或课程数少于发现阶段报告的数量时暂不写入，下次运行重试；单个学期失败后继续处理其他学期。同步更新日志及注释。

行为说明：每次运行会执行现有的学期代码探测（默认 10 至 35，共 26 次请求）；已入库学期后续新增或调整课程不会触发刷新。接口暂时漏报旧学期不会删除现有数据。

验证：使用真实内存 SQLite 数据库、模拟 API，对实际目录抓取函数验证首次运行、学期未变化、新学期出现、接口漏报学期、空发现结果、发现异常、目录抓取失败/为空/不完整及后续重试；检查主流程无条件调用发现逻辑。三个修改文件的 Python 语法检查及 `git diff --check` 均通过。尚未进行真实 iCourse 抓取验证。
