### PR TITLE
feat: allow single-lecture notes email via sub_ids

### DIFF
--- a/.github/workflows/single_run.yml
+++ b/.github/workflows/single_run.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: false
         type: boolean
+      sub_ids:
+        description: "Optional specific lecture sub_id(s) to process (comma-separated). Leave empty to process the whole course."
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: write
@@ -162,6 +167,7 @@ jobs:
           StuId: ${{ secrets.STUID }}
           UISPsw: ${{ secrets.UISPSW }}
           COURSE_IDS: ${{ inputs.course_ids }}
+          SUB_IDS: ${{ inputs.sub_ids }}
           USE_OFFICIAL_TRANSCRIPT: ${{ inputs.use_official_transcript && '1' || '' }}
           SMTP_EMAIL: ${{ secrets.SMTP_EMAIL }}
           SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -296,25 +296,31 @@
 
     <div class="space-y-2">
       <template x-for="lec in lectures" :key="lec.sub_id">
-        <button @click="lec.state === 'ready' && openLecture(lec.sub_id)"
-                :class="lec.state === 'ready' ? 'hover:shadow-md active:bg-gray-50 cursor-pointer' : 'opacity-60 cursor-default'"
-                class="w-full text-left bg-white rounded-lg border border-gray-100 p-3.5 transition-shadow">
+        <div @click="lec.state === 'ready' && openLecture(lec.sub_id)"
+             :class="lec.state === 'ready' ? 'hover:shadow-md active:bg-gray-50 cursor-pointer' : 'opacity-60'"
+             class="w-full text-left bg-white rounded-lg border border-gray-100 p-3.5 transition-shadow">
           <div class="flex items-center justify-between gap-2">
-            <h4 class="font-medium text-gray-800 text-sm truncate" x-text="lec.sub_title || 'Untitled'"></h4>
-            <span class="flex-shrink-0 text-xs px-2 py-0.5 rounded-full"
-                  :class="{
-                    'badge-ready': lec.state === 'ready',
-                    'badge-processing': lec.state === 'processing',
-                    'badge-waiting': lec.state === 'waiting' || lec.state === 'novideo',
-                    'badge-skipped': lec.state === 'skipped',
-                    'badge-failed': lec.state === 'failed'
-                  }"
-                  x-text="lec.state === 'ready' ? 'Ready' :
-                          lec.state === 'processing' ? 'Summarizing…' :
-                          lec.state === 'waiting' ? 'Waiting' :
-                          lec.state === 'novideo' ? 'No Video' :
-                          lec.state === 'skipped' ? 'No Content' :
-                          'Failed: ' + (lec.error_stage || 'unknown')"></span>
+            <div class="flex items-center gap-2 min-w-0">
+              <h4 class="font-medium text-gray-800 text-sm truncate" x-text="lec.sub_title || 'Untitled'"></h4>
+              <span class="flex-shrink-0 text-xs px-2 py-0.5 rounded-full"
+                    :class="{
+                      'badge-ready': lec.state === 'ready',
+                      'badge-processing': lec.state === 'processing',
+                      'badge-waiting': lec.state === 'waiting' || lec.state === 'novideo',
+                      'badge-skipped': lec.state === 'skipped',
+                      'badge-failed': lec.state === 'failed'
+                    }"
+                    x-text="lec.state === 'ready' ? 'Ready' :
+                            lec.state === 'processing' ? 'Summarizing…' :
+                            lec.state === 'waiting' ? 'Waiting' :
+                            lec.state === 'novideo' ? 'No Video' :
+                            lec.state === 'skipped' ? 'No Content' :
+                            'Failed: ' + (lec.error_stage || 'unknown')"></span>
+            </div>
+            <button @click.stop="runLectureWorkflow(lec.sub_id)"
+                    :disabled="lectureRunningSubId !== null"
+                    class="flex-shrink-0 text-xs text-blue-600 border border-blue-200 rounded-lg px-2 py-1 hover:bg-blue-50 disabled:opacity-50"
+                    x-text="lectureRunningSubId === String(lec.sub_id) ? '触发中…' : '单节笔记'"></button>
           </div>
           <!-- Preview snippet for ready lectures -->
           <p x-show="lec.state === 'ready' && lec.summary"
@@ -323,7 +329,7 @@
           <!-- Error detail -->
           <p x-show="lec.state === 'failed' && lec.error_msg"
              class="text-xs text-red-400 mt-1 truncate" x-text="lec.error_msg"></p>
-        </button>
+        </div>
       </template>
     </div>
   </div>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -283,6 +283,7 @@ document.addEventListener("alpine:init", () => {
     subsSaving: false, subsError: "",
     singleRunTriggering: false,
     singleRunUseOfficial: false,
+    lectureRunningSubId: null,
     /* Per-browser pinned-courses set, lazily synced to localStorage. */
     starred: _loadStarred(),
 
@@ -1003,6 +1004,42 @@ document.addEventListener("alpine:init", () => {
         this.subsError = e?.message || "触发失败";
       } finally {
         this.singleRunTriggering = false;
+      }
+    },
+
+    // ── Single-lecture run (notes email) ─────────────────────────────
+    async runLectureWorkflow(subId) {
+      if (this.lectureRunningSubId) return;
+      const courseId = this.currentCourse
+        ? String(this.currentCourse.course_id)
+        : null;
+      if (!courseId) {
+        this._toast("缺少课程上下文", "error");
+        return;
+      }
+      const creds = _loadCreds();
+      if (!creds?.token) {
+        this._toast("未登录或 PAT 缺失", "error");
+        return;
+      }
+      const targetSubId = String(subId);
+      this.lectureRunningSubId = targetSubId;
+      try {
+        // Trigger the dedicated single_run workflow scoped to exactly one
+        // lecture. The backend will reuse the existing summary if present
+        // (and re-send it) or process the recording from scratch.
+        await ICS.github.triggerSingleRunWorkflow(
+          this.repoOwner, this.repoName, "main", creds.token,
+          [courseId], false, [targetSubId],
+        );
+        this._toast(
+          "已触发单节笔记，处理完成后将发送到 RECEIVER_EMAIL",
+          "success",
+        );
+      } catch (e) {
+        this._toast(e?.message || "触发失败", "error");
+      } finally {
+        this.lectureRunningSubId = null;
       }
     },
 

--- a/frontend/js/github.js
+++ b/frontend/js/github.js
@@ -214,13 +214,16 @@ async function _setCourseIdsSecret(owner, repo, token, courseIds) {
   return value;
 }
 
-async function _triggerSingleRunWorkflow(owner, repo, ref, token, courseIds, useOfficial) {
+async function _triggerSingleRunWorkflow(owner, repo, ref, token, courseIds, useOfficial, subIds) {
   const url = `${_GH_API}/repos/${owner}/${repo}/actions/workflows/single_run.yml/dispatches`;
   const ids = (Array.isArray(courseIds) ? courseIds : [])
     .map(String).map((s) => s.trim()).filter(Boolean).join(",");
   if (!ids) throw new Error("单次运行列表为空");
   const inputs = { course_ids: ids };
   if (useOfficial) inputs.use_official_transcript = "true";
+  const wantedSubs = (Array.isArray(subIds) ? subIds : [])
+    .map(String).map((s) => s.trim()).filter(Boolean).join(",");
+  if (wantedSubs) inputs.sub_ids = wantedSubs;
   const res = await fetch(url, {
     method: "POST",
     headers: { ..._ghHeaders(token), "Content-Type": "application/json" },

--- a/main.py
+++ b/main.py
@@ -112,18 +112,31 @@ def _enumerate_lectures(client: ICourseClient, db: Database,
                     reporter.course_dedup_skip(title, lec["sub_id"])
             lectures = deduped
 
+            # 单节模式：只保留用户通过 SUB_IDS 指定的课次，忽略其余课程内课次。
+            forced_ids = set(config.SUB_IDS)
+            if forced_ids:
+                lectures = [
+                    lec for lec in lectures
+                    if str(lec.get("sub_id")) in forced_ids
+                ]
+
             known_processed = db.get_processed_sub_ids(course_id)
             new_lectures = [
                 lec for lec in lectures
                 if lec.get("has_playback")
-                and str(lec["sub_id"]) not in known_processed
+                and (
+                    str(lec["sub_id"]) not in known_processed
+                    or str(lec["sub_id"]) in forced_ids
+                )
             ]
             unprocessed = db.get_unprocessed_lectures(course_id)
             new_ids = {str(lec["sub_id"]) for lec in new_lectures}
             retry_only = [
                 {"sub_id": u["sub_id"], "sub_title": u["sub_title"],
                  "date": u["date"]}
-                for u in unprocessed if u["sub_id"] not in new_ids
+                for u in unprocessed
+                if u["sub_id"] not in new_ids
+                and (not forced_ids or u["sub_id"] in forced_ids)
             ]
             new_lectures.extend(retry_only)
             reporter.course_new_count(len(new_lectures))
@@ -174,8 +187,11 @@ def _drive_lectures(client: ICourseClient, db: Database,
 
         _check_session(client)
         try:
+            # 单节模式：若这节课已有摘要且此前已发过邮件，仍允许重新发送。
+            resend_if_emailed = str(sub_id) in set(config.SUB_IDS)
             summary = runner.run(
                 course_id, course_title, lecture, next_info=next_info,
+                resend_if_emailed=resend_if_emailed,
             )
             if summary:
                 email_items.append({

--- a/src/pipeline/lecture_runner.py
+++ b/src/pipeline/lecture_runner.py
@@ -76,12 +76,15 @@ class LectureRunner:
     # ── Public entry point ──────────────────────────────────────────────
 
     def run(self, course_id: str, course_title: str, lecture: dict,
-            next_info: Optional[tuple[str, str]] = None) -> Optional[str]:
+            next_info: Optional[tuple[str, str]] = None,
+            resend_if_emailed: bool = False) -> Optional[str]:
         """Process one lecture.  Returns the summary text or None.
 
         ``next_info``: ``(course_id, sub_id)`` of the next lecture, used to
         kick off its prefetch concurrently.  Pass ``None`` for the last
-        lecture in the batch.
+        lecture in the batch.  When ``resend_if_emailed`` is True, an
+        existing summary is re-queued for email even if it was already
+        emailed (used by single-lecture "resend notes" runs).
         """
         sub_id = str(lecture["sub_id"])
         sub_title = lecture.get("sub_title", sub_id)
@@ -100,7 +103,7 @@ class LectureRunner:
             self._db.clear_error(sub_id)
             # The return value feeds the email batch — suppress it when
             # this summary already went out so it isn't re-sent.
-            if existing.get("emailed_at"):
+            if existing.get("emailed_at") and not resend_if_emailed:
                 return None
             return existing["summary"]
 

--- a/src/runtime/config.py
+++ b/src/runtime/config.py
@@ -177,6 +177,15 @@ COURSE_IDS = [
     if c.strip()
 ]
 
+# 可选：只处理指定的课次 sub_id（逗号分隔）。用于“选择某一节回放，单独生成笔记并
+# 发送邮件”的单节运行。留空时维持原有“处理该课程所有新课次”的行为。
+# 例：SUB_IDS=657032 或 SUB_IDS=657032,657033
+SUB_IDS = [
+    s.strip()
+    for s in os.environ.get("SUB_IDS", "").split(",")
+    if s.strip()
+]
+
 # 学期级课程目录爬取（已弃用 — main.py 现在自动发现所有学期）。
 # 保留此变量仅用于兼容老部署环境，新部署无需设置。
 # 例：CRAWL_TERM=25


### PR DESCRIPTION
我将single run改成了输入course id和subjetect id就能重新整理特定一节，用新功能后发现我有问题的那一节课log显示Empty transcript, skipping summary，但是我看回放明明有声音，十分奇怪，但本身代码应该是没有bug的，
<img width="1804" height="700" alt="4d663591873d0f2e21d5da0f9fdc74e8" src="https://github.com/user-attachments/assets/5a39416c-5016-41cc-9102-0c27a0438bd3" />至于“审核中”这种状态，现在看来应该不是引起问题的主要原因吧🤔

